### PR TITLE
it: Link and description mismatch

### DIFF
--- a/content/it/_index.html
+++ b/content/it/_index.html
@@ -41,12 +41,12 @@ Kubernetes è open source, e ti offre la libertà di spostare i tuoi carichi di 
         <button id="desktopShowVideoButton" onclick="kub.showVideo()">Guarda il Video</button>
         <br>
         <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/?utm_source=kubernetes.io&utm_medium=nav&utm_campaign=kccnceu20" button id="desktopKCButton">Partecipa alla KubeCon ad Amsterdam (13-16 Agosto 2020)</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/?utm_source=kubernetes.io&utm_medium=nav&utm_campaign=kccnceu22" button id="desktopKCButton">Partecipa alla KubeCon a Valencia, Spagna + Virtual (16-20 maggio 2022)</a>
         <br>
         <br>
         <br>
         <br>
-        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/?utm_source=kubernetes.io&utm_medium=nav&utm_campaign=kccncna20" button id="desktopKCButton">Partecipa alla KubeCon a Boston (17-20 Novembre 2020)</a>
+        <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/?utm_source=kubernetes.io&utm_medium=nav&utm_campaign=kccncna22" button id="desktopKCButton">Partecipa al KubeCon a Detroit, Michigan (24-28 ottobre 2022)</a>
 </div>
 <div id="videoPlayer">
     <iframe data-url="https://www.youtube.com/embed/H06qrNmGqyE?autoplay=1" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
Updated the _index.html file `content/it/_index.html` to include the
latest links for the Cloud Native Computing Foundation’s flagship conference.
KubeCon + CloudNativeCon

These KubeCon conferences are already over but we still have :

- `Partecipa alla KubeCon ad Amsterdam (13-16 Agosto 2020)`
- `Partecipa alla KubeCon a Boston (17-20 Novembre 2020)`

These have been updated to :

- `Partecipa alla KubeCon a Valencia, Spagna + Virtual (16-20 maggio 2022)`
- `Partecipa al KubeCon a Detroit, Michigan (24-28 ottobre 2022)`

Issue : #31384